### PR TITLE
Add ability to send fault report email

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -9,7 +9,8 @@ module.exports = {
   email: {
     /* Which address to send emails from */
     sendAddress: 'noreply@buddycloud.dev',
-    reportingAddress: 'report@buddycloud.dev',
+    postReportingAddress: 'report@buddycloud.dev',
+    cityFaultReportingAddress: 'city-fault@buddycloud.dev',
     /* Connection details */
     connection: {
       user: 'user',

--- a/index.js
+++ b/index.js
@@ -123,10 +123,10 @@ primus.on('connection', function(socket) {
   buddycloud.setCache(buddycloudCache)
   xmppFtw.addListener(buddycloud)
   socket.xmppFtw = xmppFtw
-  socket.on('message.report', function(data, callback) {
+  socket.on('report.post', function(data, callback) {
     try {
       data.reportedBy = xmppFtw.getJidType('bare')
-      report.sendReport(data, callback)
+      report.sendPostReport(data, callback)
     } catch(e) {
       debug('Error with report email, likely client is not connected')
       debug(e)

--- a/index.js
+++ b/index.js
@@ -128,7 +128,16 @@ primus.on('connection', function(socket) {
       data.reportedBy = xmppFtw.getJidType('bare')
       report.sendPostReport(data, callback)
     } catch(e) {
-      debug('Error with report email, likely client is not connected')
+      debug('Error with post report email, likely client is not connected')
+      debug(e)
+    }
+  })
+  socket.on('report.fault', function(data, callback) {
+    try {
+      data.reportedBy = xmppFtw.getJidType('bare')
+      report.sendFaultReport(data, callback)
+    } catch(e) {
+      debug('Error with fault report email, likely client is not connected')
       debug(e)
     }
   })

--- a/public/scripts/app/views/Topic/Report.js
+++ b/public/scripts/app/views/Topic/Report.js
@@ -117,7 +117,7 @@ define(function(require) {
         }
         log('Sending report data', data)
         socket.send(
-          'message.report',
+          'report.post',
           data,
           function() {
             self.close(event)

--- a/src/report.js
+++ b/src/report.js
@@ -5,6 +5,10 @@ var postReportTemplate = fs.readFileSync(
   process.cwd() + '/src/templates/post-report',
   'utf8'
 )
+var sendFaultReportTemplate = fs.readFileSync(
+  process.cwd() + '/src/templates/fault-report',
+  'utf8'
+)
 
 var config = null
 
@@ -12,8 +16,30 @@ var setConfig = function(configuration) {
   config = configuration
 }
 
-var sendPostReport = function(data, callback) {
+var sendFaultReport = function(data, callback) {
 	
+  if (
+    !data.content ||
+    !data.location
+  ) {
+    /* We'll just ignore errors */
+    return callback()
+  }
+  var replacements = {
+    reportedBy: data.reportedBy,
+    description: data.description,
+    location: data.location
+  }
+  mailer.sendMail(
+    config.email.cityFaultReportingAddress,
+    'City fault report',
+    sendFaultReportTemplate, 
+    replacements,
+    function() { callback() }
+  )
+}
+
+var sendPostReport = function(data, callback) {
   if (
     !data.content ||
     !data.postId ||
@@ -32,7 +58,7 @@ var sendPostReport = function(data, callback) {
     content: data.content
   }
   mailer.sendMail(
-    config.email.reportingAddress,
+    config.email.postReportingAddress,
     'Post on wifi chat being reported',
     postReportTemplate, 
     replacements,
@@ -42,5 +68,6 @@ var sendPostReport = function(data, callback) {
 
 module.exports = {
   sendPostReport: sendPostReport,
+  sendFaultReport: sendFaultReport,
   setConfig: setConfig
 }

--- a/src/report.js
+++ b/src/report.js
@@ -12,7 +12,7 @@ var setConfig = function(configuration) {
   config = configuration
 }
 
-var sendReport = function(data, callback) {
+var sendPostReport = function(data, callback) {
 	
   if (
     !data.content ||
@@ -41,6 +41,6 @@ var sendReport = function(data, callback) {
 }
 
 module.exports = {
-  sendReport: sendReport,
+  sendPostReport: sendPostReport,
   setConfig: setConfig
 }

--- a/src/templates/fault-report
+++ b/src/templates/fault-report
@@ -1,0 +1,11 @@
+--- Description of fault ---
+
+%description%
+
+--- Location ---
+
+%location%
+
+--- Reported By ---
+
+%reportedBy%


### PR DESCRIPTION
@imaginator note the reportingAddress config key has changed and there is no an additional config setting for the fault reporting email.

This does not include any front end work as I'll leave this in the capable hands of @mrflix 

The template (stored in the templates directory) can be edited as required. We need to pass two pieces of data to the code using the '''report.fault''' event:

``` json
{
  "description": "There's a broken light",
  "location": "Some text description - use could use geo loc from phone here"
}
```

This can be merged without breaking the front end provided config changes are made on the server.
