### PR TITLE
.gitignore: ignore v8.log (and save 821 MB installed size)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 npm-debug.log
+v8.log
 node_modules
 public/scripts/primus.js
 public/app.min.*


### PR DESCRIPTION
Your npm package [isizwe-wifi-chat](https://www.npmjs.com/package/isizwe-wifi-chat) unpacked size is **833 MB**, making it the third-largest package on `npm` measured by installed size of the latest version AFAIK.

**821MB** of that is the `v8.log` file in the package root.

You should probably put that file to the `.gitignore`.
